### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM nvcr.io/nvidia/l4t-pytorch:r32.5.0-pth1.6-py3
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update
+RUN apt-get update
 RUN apt install -y cmake libgtk2.0-dev wget
 # ffmpeg
 RUN apt install -y libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavresample3


### PR DESCRIPTION
Hi, while testing the repo and building the dockerfile I just noticed some minor error in the Dockerfile which caused the following error log to occur in step 6 ```RUN apt install -y libgstreamer-opencv1.0-0 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev```: 

```
Step 6/17 : RUN apt install -y libgstreamer-opencv1.0-0 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev
 ---> Running in 69b3bcb6b3f4

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  gir1.2-gst-plugins-base-1.0 gir1.2-gstreamer-1.0 libegl1-mesa-dev
  libgles2-mesa-dev libopencv-core3.2 liborc-0.4-dev liborc-0.4-dev-bin
  libtbb2 libwayland-bin libwayland-dev
Suggested packages:
  gstreamer1.0-doc liborc-0.4-doc libwayland-doc
The following NEW packages will be installed:
  gir1.2-gst-plugins-base-1.0 gir1.2-gstreamer-1.0 libegl1-mesa-dev
  libgles2-mesa-dev libgstreamer-opencv1.0-0 libgstreamer-plugins-base1.0-dev
  libgstreamer1.0-dev libopencv-core3.2 liborc-0.4-dev liborc-0.4-dev-bin
  libtbb2 libwayland-bin libwayland-dev
0 upgraded, 13 newly installed, 0 to remove and 55 not upgraded.
Need to get 2077 kB of archives.
After this operation, 17.4 MB of additional disk space will be used.
Err:1 http://ports.ubuntu.com/ubuntu-ports bionic-updates/main arm64 gir1.2-gstreamer-1.0 arm64 1.14.5-0ubuntu1~18.04.1
  404  Not Found [IP: 91.189.88.152 80]
Err:2 http://ports.ubuntu.com/ubuntu-ports bionic-updates/main arm64 gir1.2-gst-plugins-base-1.0 arm64 1.14.5-0ubuntu1~18.04.1
  404  Not Found [IP: 91.189.88.152 80]
Get:3 http://ports.ubuntu.com/ubuntu-ports bionic-updates/main arm64 libwayland-bin arm64 1.16.0-1ubuntu1.1~18.04.3 [17.9 kB]
Get:4 http://ports.ubuntu.com/ubuntu-ports bionic-updates/main arm64 libwayland-dev arm64 1.16.0-1ubuntu1.1~18.04.3 [62.8 kB]
Get:5 http://ports.ubuntu.com/ubuntu-ports bionic-updates/main arm64 libegl1-mesa-dev arm64 20.0.8-0ubuntu1~18.04.1 [20.5 kB]
Get:6 http://ports.ubuntu.com/ubuntu-ports bionic-updates/main arm64 libgles2-mesa-dev arm64 20.0.8-0ubuntu1~18.04.1 [45.0 kB]
Err:7 http://ports.ubuntu.com/ubuntu-ports bionic-updates/main arm64 libgstreamer1.0-dev arm64 1.14.5-0ubuntu1~18.04.1
  404  Not Found [IP: 91.189.88.152 80]
Get:8 http://ports.ubuntu.com/ubuntu-ports bionic/main arm64 liborc-0.4-dev-bin arm64 1:0.4.28-1 [137 kB]
Get:9 http://ports.ubuntu.com/ubuntu-ports bionic/main arm64 liborc-0.4-dev arm64 1:0.4.28-1 [156 kB]
Err:10 http://ports.ubuntu.com/ubuntu-ports bionic-updates/main arm64 libgstreamer-plugins-base1.0-dev arm64 1.14.5-0ubuntu1~18.04.1
  404  Not Found [IP: 91.189.88.152 80]
Get:11 http://ports.ubuntu.com/ubuntu-ports bionic/universe arm64 libtbb2 arm64 2017~U7-8 [87.8 kB]
Get:12 http://ports.ubuntu.com/ubuntu-ports bionic-updates/universe arm64 libopencv-core3.2 arm64 3.2.0+dfsg-4ubuntu0.1 [631 kB]
Get:13 http://ports.ubuntu.com/ubuntu-ports bionic-updates/universe arm64 libgstreamer-opencv1.0-0 arm64 1.14.5-0ubuntu1~18.04.1 [54.7 kB]
Fetched 1213 kB in 2s (725 kB/s)
E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/g/gstreamer1.0/gir1.2-gstreamer-1.0_1.14.5-0ubuntu1~18.04.1_arm64.deb  404  Not Found [IP: 91.189.88.152 80]
E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/g/gst-plugins-base1.0/gir1.2-gst-plugins-base-1.0_1.14.5-0ubuntu1~18.04.1_arm64.deb  404  Not Found [IP: 91.189.88.152 80]
E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/g/gstreamer1.0/libgstreamer1.0-dev_1.14.5-0ubuntu1~18.04.1_arm64.deb  404  Not Found [IP: 91.189.88.152 80]
E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/g/gst-plugins-base1.0/libgstreamer-plugins-base1.0-dev_1.14.5-0ubuntu1~18.04.1_arm64.deb  404  Not Found [IP: 91.189.88.152 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The command '/bin/sh -c apt install -y libgstreamer-opencv1.0-0 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev' returned a non-zero code: 100
```
Solution was to replace ```RUN apt update``` with ```RUN apt-get update```

best,
Abu

